### PR TITLE
Add bilingual AI News Radar skill triggers

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@
 
 ## 24 小时 AI 更新雷达｜伯乐Skill
 
-**伯乐Skill帮你从一堆信源里选出千里马。**
+**伯乐Skill（Scout Skill）帮你从一堆信源里选出千里马。**
 
 [![GitHub Pages](https://img.shields.io/badge/GitHub%20Pages-Live-green?style=flat-square)](https://learnprompt.github.io/ai-news-radar/)
 [![Actions](https://img.shields.io/github/actions/workflow/status/LearnPrompt/ai-news-radar/update-news.yml?branch=master&label=update&style=flat-square)](https://github.com/LearnPrompt/ai-news-radar/actions/workflows/update-news.yml)
 [![License](https://img.shields.io/badge/license-MIT-green.svg?style=flat-square)](LICENSE)
 
-你只负责看更新，伯乐Skill负责从一堆信源里选出千里马。
+你只负责看更新，伯乐Skill负责从一堆信源里选出千里马；英文展示名是Scout Skill。
 
 [在线页面](https://learnprompt.github.io/ai-news-radar/) · [English](README.en.md) · [伯乐Skill](skills/ai-news-radar/README.md) · [信息源策略](docs/SOURCE_COVERAGE.md)
 

--- a/index.html
+++ b/index.html
@@ -6,13 +6,13 @@
     <title>AI News Radar｜24 小时 AI 更新雷达</title>
     <meta
       name="description"
-      content="自动整理过去 24 小时值得看的 AI、模型和开发者工具更新；伯乐Skill帮你从一堆信源里选出千里马。"
+      content="自动整理过去 24 小时值得看的 AI、模型和开发者工具更新；伯乐Skill（Scout Skill）帮你从一堆信源里选出千里马。"
     />
     <link rel="canonical" href="https://learnprompt.github.io/ai-news-radar/" />
     <meta property="og:title" content="AI News Radar｜24 小时 AI 更新雷达" />
     <meta
       property="og:description"
-      content="自动整理过去 24 小时值得看的 AI、模型和开发者工具更新；伯乐Skill帮你从一堆信源里选出千里马。"
+      content="自动整理过去 24 小时值得看的 AI、模型和开发者工具更新；伯乐Skill（Scout Skill）帮你从一堆信源里选出千里马。"
     />
     <meta property="og:type" content="website" />
     <meta property="og:url" content="https://learnprompt.github.io/ai-news-radar/" />
@@ -21,7 +21,7 @@
     <meta name="twitter:title" content="AI News Radar｜24 小时 AI 更新雷达" />
     <meta
       name="twitter:description"
-      content="自动整理过去 24 小时值得看的 AI、模型和开发者工具更新；伯乐Skill帮你从一堆信源里选出千里马。"
+      content="自动整理过去 24 小时值得看的 AI、模型和开发者工具更新；伯乐Skill（Scout Skill）帮你从一堆信源里选出千里马。"
     />
     <link rel="icon" href="./assets/logo.svg" type="image/svg+xml" />
     <link rel="stylesheet" href="./assets/styles.css" />

--- a/skills/ai-news-radar/SKILL.md
+++ b/skills/ai-news-radar/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ai-news-radar
-description: "Use when working on AI News Radar or Scout Skill: finding high-signal AI/tech sources, adding RSS/OPML/GitHub feeds, checking source health, updating the web UI, GitHub Actions, or GitHub Pages deployment."
+description: "Use when working on AI News Radar, 24 小时 AI 更新雷达, AI 更新雷达, 伯乐Skill, or Scout Skill: finding high-signal AI/tech sources, adding RSS/OPML/GitHub feeds, checking source health, updating the web UI, GitHub Actions, or GitHub Pages deployment."
 ---
 
 # AI News Radar


### PR DESCRIPTION
## Summary
- Add Chinese product aliases and 伯乐Skill to the Skill trigger description
- Add Scout Skill mapping to the Chinese README hero copy
- Add 伯乐Skill（Scout Skill）to page/share descriptions

## Verification
- python -m py_compile scripts/update_news.py
- python -m pytest -q
- node --check assets/app.js
- git diff --check
- quick_validate.py skills/ai-news-radar