### PR TITLE
fix: five quality issues from the live-page review

### DIFF
--- a/assets/app.js
+++ b/assets/app.js
@@ -783,6 +783,8 @@ function renderItemNode(item) {
   return node;
 }
 
+const GROUP_RENDER_CAP = 15;
+
 function buildSourceGroupNode(source, items) {
   const section = document.createElement("section");
   section.className = "source-group";
@@ -796,7 +798,21 @@ function buildSourceGroupNode(source, items) {
   listEl.className = "source-group-list";
   header.append(title, count);
   section.append(header, listEl);
-  items.forEach((item) => listEl.appendChild(renderItemNode(item)));
+  // Render a capped slice up front; the rest of the nodes are only created
+  // on demand so an 800-item day cannot stall first paint.
+  items.slice(0, GROUP_RENDER_CAP).forEach((item) => listEl.appendChild(renderItemNode(item)));
+  const rest = items.slice(GROUP_RENDER_CAP);
+  if (rest.length) {
+    const moreBtn = document.createElement("button");
+    moreBtn.type = "button";
+    moreBtn.className = "group-more-btn";
+    moreBtn.textContent = `展开剩余 ${fmtNumber(rest.length)} 条`;
+    moreBtn.addEventListener("click", () => {
+      rest.forEach((item) => listEl.appendChild(renderItemNode(item)));
+      moreBtn.remove();
+    });
+    section.append(moreBtn);
+  }
   return section;
 }
 

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1010,6 +1010,24 @@ summary:focus-visible {
   display: grid;
 }
 
+.group-more-btn {
+  display: block;
+  width: 100%;
+  padding: 9px 12px;
+  border: 0;
+  border-top: 1px dashed var(--line);
+  background: var(--surface-soft);
+  color: var(--muted);
+  font-size: 12.5px;
+  cursor: pointer;
+  text-align: center;
+}
+
+.group-more-btn:hover {
+  color: var(--ink);
+  background: var(--surface);
+}
+
 .site-group {
   min-width: 0;
   border-top: 1px solid rgba(23, 23, 23, 0.08);
@@ -1424,10 +1442,29 @@ summary:focus-visible {
     align-items: flex-start;
   }
 
+  /* Keep two columns on phones: a single column turns ten stat cards into
+     three screens of dashboard before the first piece of content. */
   .stats,
   .coverage-strip,
   .health-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 6px;
+  }
+
+  .stat {
+    padding: 8px 10px;
+  }
+
+  .stat .v {
+    font-size: 18px;
+  }
+
+  .coverage-card {
+    padding: 8px 9px;
+  }
+
+  .coverage-card strong {
+    font-size: 14px;
   }
 
   .waytoagi-tools {

--- a/scripts/ai_relevance.py
+++ b/scripts/ai_relevance.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 
 import re
 from typing import Any
+from urllib.parse import urlparse
 
 AI_KEYWORDS = [
+    "a.i.",
     "agent view",
     "agent skills",
     "for agents",
@@ -216,7 +218,14 @@ def score_ai_relevance(record: dict[str, Any]) -> dict[str, Any]:
     source = str(record.get("source") or "")
     site_name = str(record.get("site_name") or "")
     url = str(record.get("url") or "")
-    text = f"{title} {source} {site_name} {url}".lower()
+    # Keyword matching is substring-based, so only the URL host may participate:
+    # full URLs (e.g. Google News base64 paths) randomly contain substrings like
+    # "llm"/"gpt" and turn unrelated world news into "AI" items.
+    try:
+        url_host = (urlparse(url).netloc or "").lower()
+    except Exception:
+        url_host = ""
+    text = f"{title} {source} {site_name} {url_host}".lower()
 
     ai_signals = matched_keywords(text, AI_KEYWORDS)
     tech_signals = matched_keywords(text, TECH_KEYWORDS)

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -3049,6 +3049,69 @@ def dedupe_items_by_title_url(items: list[dict[str, Any]], random_pick: bool = T
     return out
 
 
+def suppress_near_duplicate_items(
+    items: list[dict[str, Any]],
+    window_hours: float = 6.0,
+    similarity_threshold: float = 0.9,
+) -> list[dict[str, Any]]:
+    """Collapse near-identical items from the same site (rewritten syndication,
+    e.g. "推出法案" vs "推出立法") that exact title||url dedup cannot catch.
+    Keeps the more authoritative copy (tier, then ai_score, then earliest)."""
+
+    def quality(item: dict[str, Any]) -> tuple:
+        tier_rank = item.get("source_tier_rank")
+        try:
+            tier_rank = int(tier_rank)
+        except Exception:
+            tier_rank = 99
+        try:
+            score = float(item.get("ai_score") or 0)
+        except Exception:
+            score = 0.0
+        ts = event_time(item) or datetime.max.replace(tzinfo=UTC)
+        return (-tier_rank, score, -ts.timestamp())
+
+    by_site: dict[str, list[dict[str, Any]]] = {}
+    for item in items:
+        by_site.setdefault(str(item.get("site_id") or ""), []).append(item)
+
+    dropped_ids: set[str] = set()
+    for site_items in by_site.values():
+        ordered = sorted(site_items, key=lambda x: event_time(x) or datetime.min.replace(tzinfo=UTC))
+        kept: list[tuple[dict[str, Any], str, set[str], datetime | None]] = []
+        for item in ordered:
+            title = normalized_story_title(item)
+            tokens = title_tokens(title)
+            ts = event_time(item)
+            if not title_is_mergeable(title):
+                kept.append((item, title, tokens, ts))
+                continue
+            duplicate_of = None
+            for kept_entry in reversed(kept[-60:]):
+                other, other_title, other_tokens, other_ts = kept_entry
+                if ts and other_ts and abs((ts - other_ts).total_seconds()) / 3600 > window_hours:
+                    continue
+                if not tokens or not other_tokens:
+                    continue
+                jaccard = len(tokens & other_tokens) / len(tokens | other_tokens)
+                if jaccard < 0.5:
+                    continue
+                if title_similarity(title, other_title) >= similarity_threshold and story_titles_can_merge(title, other_title):
+                    duplicate_of = kept_entry
+                    break
+            if duplicate_of is None:
+                kept.append((item, title, tokens, ts))
+                continue
+            other = duplicate_of[0]
+            if quality(item) > quality(other):
+                dropped_ids.add(str(other.get("id") or id(other)))
+                kept[kept.index(duplicate_of)] = (item, title, tokens, ts)
+            else:
+                dropped_ids.add(str(item.get("id") or id(item)))
+
+    return [item for item in items if str(item.get("id") or id(item)) not in dropped_ids]
+
+
 def canonical_story_url(raw_url: str) -> str:
     normalized = normalize_url(raw_url)
     try:
@@ -3336,6 +3399,33 @@ def merge_story_items(
     return stories, events
 
 
+def select_diverse_stories(
+    stories: list[dict[str, Any]],
+    limit: int,
+    same_source_penalty: float = 0.03,
+) -> list[dict[str, Any]]:
+    """Greedy top-N by score with a per-source decay so one prolific source
+    cannot fill the brief with a run of same-score stories."""
+    candidates = sorted(stories, key=lambda story: (-float(story.get("score") or 0), str(story.get("title") or "")))
+    picked: list[dict[str, Any]] = []
+    picked_per_source: dict[str, int] = {}
+    remaining = list(candidates)
+    while remaining and len(picked) < limit:
+        best_idx = 0
+        best_eff = float("-inf")
+        for idx, story in enumerate(remaining):
+            source = str(story.get("source") or story.get("source_name") or "")
+            eff = float(story.get("score") or 0) - same_source_penalty * picked_per_source.get(source, 0)
+            if eff > best_eff:
+                best_eff = eff
+                best_idx = idx
+        chosen = remaining.pop(best_idx)
+        source = str(chosen.get("source") or chosen.get("source_name") or "")
+        picked_per_source[source] = picked_per_source.get(source, 0) + 1
+        picked.append(chosen)
+    return picked
+
+
 def build_daily_brief_payload(
     stories: list[dict[str, Any]],
     generated_at: str,
@@ -3344,7 +3434,7 @@ def build_daily_brief_payload(
     max_items: int = 20,
 ) -> dict[str, Any]:
     limit = len(stories) if len(stories) < min_items else min(max_items, len(stories))
-    items = sorted(stories, key=lambda story: (-float(story.get("score") or 0), str(story.get("title") or "")))[:limit]
+    items = select_diverse_stories(stories, limit)
     return {
         "generated_at": generated_at,
         "window_hours": window_hours,
@@ -3558,7 +3648,7 @@ def main() -> int:
         title_cache,
         max_new_translations=max(0, args.translate_max_new),
     )
-    latest_items_ai_dedup = dedupe_items_by_title_url(latest_items, random_pick=False)
+    latest_items_ai_dedup = suppress_near_duplicate_items(dedupe_items_by_title_url(latest_items, random_pick=False))
     latest_items_all_dedup = dedupe_items_by_title_url(latest_items_all, random_pick=True)
     stories, merge_events = merge_story_items(latest_items_ai_dedup, now=now, window_hours=args.window_hours)
     generated_at = iso(now)

--- a/tests/test_quality_fixes.py
+++ b/tests/test_quality_fixes.py
@@ -1,0 +1,118 @@
+"""Tests for the v0.6.x quality fixes: URL-host-only relevance matching,
+same-source decay in the daily brief, and near-duplicate item suppression."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from scripts.ai_relevance import score_ai_relevance
+from scripts.update_news import select_diverse_stories, suppress_near_duplicate_items
+
+
+NOW = datetime(2026, 6, 11, 12, 0, tzinfo=timezone.utc)
+
+
+class TestUrlHostOnlyRelevance:
+    def test_base64_url_path_cannot_fake_ai_signal(self):
+        # Real-world case: Google News base64 path contains "llm" by accident.
+        rec = {
+            "site_id": "buzzing",
+            "site_name": "Buzzing",
+            "source": "news.google.com",
+            "title": "巴勒斯坦人称，以色列定居者阻碍了村庄附近的灭火工作 - Reuters",
+            "url": "https://news.google.com/rss/articles/CBMiwgFBVllmRkNCSmxQNnR6WktHcmdMQ2NuNHFjUmlEQk1nTGxsbUFCMEhRaEExWXg3?oc=5",
+        }
+        result = score_ai_relevance(rec)
+        assert not result["is_ai_related"]
+        assert result["label"] == "not_ai"
+
+    def test_url_host_still_contributes_signal(self):
+        rec = {
+            "site_id": "opmlrss",
+            "site_name": "OPML RSS",
+            "source": "Some Blog",
+            "title": "Weekly product update",
+            "url": "https://openai.com/blog/weekly-update",
+        }
+        result = score_ai_relevance(rec)
+        assert result["is_ai_related"]
+
+    def test_dotted_ai_styled_title_keeps_signal(self):
+        rec = {
+            "site_id": "buzzing",
+            "site_name": "Buzzing",
+            "source": "news.google.com",
+            "title": "Trump Muses About Government Taking a Piece of A.I. Companies - NYT",
+            "url": "https://news.google.com/rss/articles/CCC?oc=5",
+        }
+        result = score_ai_relevance(rec)
+        assert result["is_ai_related"]
+
+
+def make_story(idx: int, source: str, score: float) -> dict:
+    return {
+        "story_id": f"story_{idx}",
+        "title": f"Story {idx}",
+        "source": source,
+        "score": score,
+    }
+
+
+class TestSelectDiverseStories:
+    def test_one_prolific_source_cannot_fill_the_brief(self):
+        stories = [make_story(i, "AIbase", 0.81) for i in range(15)]
+        stories += [make_story(100 + i, f"Official {i}", 0.78) for i in range(10)]
+        picked = select_diverse_stories(stories, 20)
+        aibase = sum(1 for s in picked if s["source"] == "AIbase")
+        assert len(picked) == 20
+        assert aibase < 15
+        assert any(s["source"].startswith("Official") for s in picked[:10])
+
+    def test_top_story_always_survives(self):
+        stories = [make_story(0, "AIbase", 0.95)] + [make_story(i, f"S{i}", 0.5) for i in range(1, 5)]
+        picked = select_diverse_stories(stories, 3)
+        assert picked[0]["story_id"] == "story_0"
+
+
+def make_dup_item(idx: int, title: str, minutes_ago: int, site_id: str = "buzzing", tier_rank: int = 5) -> dict:
+    ts = (NOW - timedelta(minutes=minutes_ago)).isoformat()
+    return {
+        "id": f"item_{idx}",
+        "site_id": site_id,
+        "site_name": site_id,
+        "source": "news.google.com",
+        "title": title,
+        "url": f"https://example.com/{idx}",
+        "published_at": ts,
+        "first_seen_at": ts,
+        "source_tier_rank": tier_rank,
+        "ai_score": 0.65,
+    }
+
+
+class TestSuppressNearDuplicateItems:
+    def test_rewritten_syndication_collapses(self):
+        a = make_dup_item(1, "加拿大推出法案，禁止16岁以下儿童使用社交媒体，并对人工智能聊天机器人进行监管 - Reuters", 10)
+        b = make_dup_item(2, "加拿大推出立法，禁止16岁以下儿童使用社交媒体，并对人工智能聊天机器人进行监管 - Reuters", 9)
+        out = suppress_near_duplicate_items([a, b])
+        assert len(out) == 1
+
+    def test_distinct_stories_survive(self):
+        a = make_dup_item(1, "OpenAI 发布 GPT-6 模型，推理能力大幅提升", 10)
+        b = make_dup_item(2, "Anthropic 发布 Claude 6 模型，推理能力大幅提升", 9)
+        out = suppress_near_duplicate_items([a, b])
+        assert len(out) == 2
+
+    def test_cross_site_duplicates_are_kept(self):
+        a = make_dup_item(1, "加拿大推出法案，禁止16岁以下儿童使用社交媒体，并对人工智能聊天机器人进行监管", 10, site_id="buzzing")
+        b = make_dup_item(2, "加拿大推出立法，禁止16岁以下儿童使用社交媒体，并对人工智能聊天机器人进行监管", 9, site_id="techurls")
+        out = suppress_near_duplicate_items([a, b])
+        assert len(out) == 2
+
+    def test_keeps_more_authoritative_copy(self):
+        low = make_dup_item(1, "小米开源终端 AI 编程助手 MiMo Code，内置免费顶级多模态模型", 10, tier_rank=5)
+        high = make_dup_item(2, "小米开源终端AI编程助手 MiMo Code，内置免费顶级多模态模型", 9, tier_rank=0)
+        high["site_id"] = "buzzing"
+        out = suppress_near_duplicate_items([low, high])
+        assert len(out) == 1
+        assert out[0]["id"] == "item_2"


### PR DESCRIPTION
Fixes the five issues found while reviewing the GitHub Pages deployment.

## Data layer

1. **False-AI items from URL noise** — keyword matching is substring-based and the full URL participated in the match text, so Google News base64 paths randomly containing `llm`/`gpt` turned wildfires/spy-planes/CPI news into `model_release 0.65` items. Only the URL host participates now. On live data: 23 false-AI items flip to `not_ai`, zero genuine items lost (added `a.i.` keyword for NYT-styled titles).
2. **One source filling Bole picks** — top-20 was pure score sort; on score ties AIbase held 15/20. `select_diverse_stories` adds a per-source decay during greedy selection → 4/20 max share on the same data.
3. **Rewritten syndication duplicates** — `法案` vs `立法` posted seconds apart survived exact title‖url dedup. `suppress_near_duplicate_items` collapses same-site items within 6h at ≥0.9 title similarity, keeping the more authoritative copy.

## UI layer

4. **Mobile stats wall** — the ≤460px breakpoint dropped stats to one column, pushing content three screens down. Two compact columns now; all stats fit one screen at 390px.
5. **800+ cards on first paint** — each source group renders 15 cards and defers the rest behind an `展开剩余 N 条` button (nodes created on click). First paint: 806 → 523 cards, page height −30%.

## Verification

- 9 new tests in `tests/test_quality_fixes.py`; full suite 74 passed
- Data fixes replayed against today's live `latest-24h.json` / `stories-merged.json`
- UI verified in browser at 1440px and 390px; expand button exercised

🤖 Generated with [Claude Code](https://claude.com/claude-code)