### PR TITLE
feat: add QQ Agent Mail source adapter

### DIFF
--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -63,6 +63,7 @@ jobs:
           AGENTMAIL_API_BASE_URL: ${{ vars.AGENTMAIL_API_BASE_URL }}
           AGENTMAIL_LIMIT: ${{ vars.AGENTMAIL_LIMIT }}
           AGENTMAIL_ALLOWED_SENDER_DOMAINS: ${{ vars.AGENTMAIL_ALLOWED_SENDER_DOMAINS }}
+          AGENTMAIL_RESOLVE_PUBLIC_URLS: ${{ secrets.AGENTMAIL_RESOLVE_PUBLIC_URLS || vars.AGENTMAIL_RESOLVE_PUBLIC_URLS }}
           EMAIL_DIGEST_INCLUDE_IN_RADAR: ${{ secrets.EMAIL_DIGEST_INCLUDE_IN_RADAR || vars.EMAIL_DIGEST_INCLUDE_IN_RADAR }}
           # Paid X/social sources (X API, SocialData, TikHub): keys live in
           # secrets; optional tuning variables override code defaults.

--- a/.github/workflows/update-news.yml
+++ b/.github/workflows/update-news.yml
@@ -56,11 +56,14 @@ jobs:
       - name: Update data
         env:
           EMAIL_DIGEST_ENABLED: ${{ secrets.EMAIL_DIGEST_ENABLED || vars.EMAIL_DIGEST_ENABLED }}
+          AGENTMAIL_PROVIDER: ${{ vars.AGENTMAIL_PROVIDER }}
+          AGENTMAIL_CLI: ${{ vars.AGENTMAIL_CLI }}
           AGENTMAIL_API_KEY: ${{ secrets.AGENTMAIL_API_KEY }}
           AGENTMAIL_INBOX_ID: ${{ secrets.AGENTMAIL_INBOX_ID }}
           AGENTMAIL_API_BASE_URL: ${{ vars.AGENTMAIL_API_BASE_URL }}
           AGENTMAIL_LIMIT: ${{ vars.AGENTMAIL_LIMIT }}
           AGENTMAIL_ALLOWED_SENDER_DOMAINS: ${{ vars.AGENTMAIL_ALLOWED_SENDER_DOMAINS }}
+          EMAIL_DIGEST_INCLUDE_IN_RADAR: ${{ secrets.EMAIL_DIGEST_INCLUDE_IN_RADAR || vars.EMAIL_DIGEST_INCLUDE_IN_RADAR }}
           # Paid X/social sources (X API, SocialData, TikHub): keys live in
           # secrets; optional tuning variables override code defaults.
           # Policy is key-first: a key present => the source runs; ENABLED is

--- a/README.md
+++ b/README.md
@@ -282,7 +282,8 @@ python scripts/update_news.py --output-dir data --window-hours 24 --rss-opml fee
 - 如果设置 `TITLE_ENHANCE_MAX_PER_RUN`，会限制每次运行最多改写的标题条数；不设置默认 30
 - 如果没有设置 `FOLLOW_OPML_B64`，线上工作流会自动使用公开示例 `feeds/follow.example.opml`，让页面展示 RSS/OPML 能力
 - 如果设置 `FOLLOW_OPML_B64`，会优先自动解码为私有 `feeds/follow.opml`
-- 如果设置 `EMAIL_DIGEST_ENABLED=1`、`AGENTMAIL_API_KEY`、`AGENTMAIL_INBOX_ID`，会生成脱敏邮箱摘要
+- 如果设置 `EMAIL_DIGEST_ENABLED=1`，会生成脱敏邮箱摘要；`AGENTMAIL_PROVIDER=agently_cli` 通过已授权的 QQ Agent Mail CLI 读取 `message +list` 元数据，`AGENTMAIL_PROVIDER=api` 兼容旧 `AGENTMAIL_API_KEY` / `AGENTMAIL_INBOX_ID` 模式
+- 只有额外设置 `EMAIL_DIGEST_INCLUDE_IN_RADAR=1`，才会把邮件 subject / snippet / sender domain / timestamp 作为独立 `agentmail` 源放进 Radar 主数据
 - 只有额外设置 `EMAIL_DIGEST_PUBLISH=1`，才会提交 `data/email-digest.json`
 - 如果设置 `X_API_ENABLED=1`、`X_BEARER_TOKEN` 和预算变量，会在每日指定UTC窗口用官方X API抓取少量公开Post；默认关闭，且当前X API按返回资源计费
 - 如果设置 `SOCIALDATA_ENABLED=1`、`SOCIALDATA_API_KEY` 和预算变量，会按 `SOCIALDATA_RUN_INTERVAL_HOURS`（默认12小时）通过 SocialData.tools 抓取少量公开 X/Twitter 搜索结果；默认关闭，API Key 只应放在本地环境变量或 GitHub Secrets

--- a/README.md
+++ b/README.md
@@ -283,7 +283,9 @@ python scripts/update_news.py --output-dir data --window-hours 24 --rss-opml fee
 - 如果没有设置 `FOLLOW_OPML_B64`，线上工作流会自动使用公开示例 `feeds/follow.example.opml`，让页面展示 RSS/OPML 能力
 - 如果设置 `FOLLOW_OPML_B64`，会优先自动解码为私有 `feeds/follow.opml`
 - 如果设置 `EMAIL_DIGEST_ENABLED=1`，会生成脱敏邮箱摘要；`AGENTMAIL_PROVIDER=agently_cli` 通过已授权的 QQ Agent Mail CLI 读取 `message +list` 元数据，`AGENTMAIL_PROVIDER=api` 兼容旧 `AGENTMAIL_API_KEY` / `AGENTMAIL_INBOX_ID` 模式
+- 如果额外设置 `AGENTMAIL_RESOLVE_PUBLIC_URLS=1`，QQ Agent Mail CLI 模式会对每封候选邮件执行一次 `message +read`，只抽取 `Read online` / `View in browser` 这类公开 newsletter 链接；正文不会写入任何 JSON。没有公开链接的邮件不会进入 Radar 主列表，避免跳到私有邮箱首页
 - 只有额外设置 `EMAIL_DIGEST_INCLUDE_IN_RADAR=1`，才会把邮件 subject / snippet / sender domain / timestamp 作为独立 `agentmail` 源放进 Radar 主数据
+- AgentMail 进入 Radar 的标题会和其它英文源一样走双语标题流程：有 `DEEPSEEK_API_KEY` 时优先 DeepSeek 翻译，没有时回退谷歌翻译；翻译数量仍受 `--translate-max-new` / `--translate-max-new-broad` 限制
 - 只有额外设置 `EMAIL_DIGEST_PUBLISH=1`，才会提交 `data/email-digest.json`
 - 如果设置 `X_API_ENABLED=1`、`X_BEARER_TOKEN` 和预算变量，会在每日指定UTC窗口用官方X API抓取少量公开Post；默认关闭，且当前X API按返回资源计费
 - 如果设置 `SOCIALDATA_ENABLED=1`、`SOCIALDATA_API_KEY` 和预算变量，会按 `SOCIALDATA_RUN_INTERVAL_HOURS`（默认12小时）通过 SocialData.tools 抓取少量公开 X/Twitter 搜索结果；默认关闭，API Key 只应放在本地环境变量或 GitHub Secrets

--- a/docs/CONFIG_REFERENCE.md
+++ b/docs/CONFIG_REFERENCE.md
@@ -132,6 +132,8 @@ SocialData 同时跑两路:① 中英关键词搜索发现新声音;② 一个�
 **Variables(可选,只当急停开关用):**
 `SOCIALDATA_ENABLED`、`TIKHUB_ENABLED`、`X_API_ENABLED` —— 不设=默认开;设 `0`=关。
 
+AgentMail 另有本地/私有运行变量：`EMAIL_DIGEST_ENABLED=1` 打开邮箱摘要，`AGENTMAIL_PROVIDER=agently_cli` 使用已授权的 QQ `agently-cli message +list`，`EMAIL_DIGEST_INCLUDE_IN_RADAR=1` 才把 metadata-only 邮件摘要作为 `agentmail` 源加入主 Radar 数据。
+
 其余所有调参(query / 排序 / 时间窗 / 每日上限 / 间隔 / 平台)**全部已搬进代码常量,GitHub 上不用再配**。
 
 ---

--- a/docs/SOURCE_COVERAGE.md
+++ b/docs/SOURCE_COVERAGE.md
@@ -179,13 +179,17 @@ baseline, then let the aggregator layer add breadth.
   `xiaohongshu_web_v3.fetch_search_notes`, records the `search_surface` in
   public raw output, and treats Web V3 failures as non-fatal when App V2
   succeeds.
-- **AgentMail digest**: supported as an advanced, secret-backed metadata digest
-  through `EMAIL_DIGEST_ENABLED=1`, `AGENTMAIL_API_KEY`, and
-  `AGENTMAIL_INBOX_ID`, but disabled by default. It deliberately lists messages
+- **AgentMail digest**: supported as an advanced metadata-only source through
+  `EMAIL_DIGEST_ENABLED=1`, but disabled by default. For the current QQ Agent
+  Mail path, set `AGENTMAIL_PROVIDER=agently_cli` after `agently-cli auth login`;
+  the fetcher only calls `agently-cli message +list` and never reads bodies. The
+  legacy API path remains available with `AGENTMAIL_PROVIDER=api`,
+  `AGENTMAIL_API_KEY`, and `AGENTMAIL_INBOX_ID`. It deliberately lists messages
   only and does not publish body text, raw `.eml`, full email addresses, or
-  secrets. For a single-newsletter demo, set
-  `AGENTMAIL_ALLOWED_SENDER_DOMAINS=alphasignal.ai` to keep shared-inbox output
-  scoped to AlphaSignal metadata.
+  secrets. Use `AGENTMAIL_ALLOWED_SENDER_DOMAINS` to scope a shared inbox. Only
+  set `EMAIL_DIGEST_INCLUDE_IN_RADAR=1` when the maintainer explicitly wants
+  subject/snippet metadata to appear as the standalone `agentmail` source in
+  Radar data.
 
 See `docs/research/advanced-source-free-tier-budget-2026-05-10.md` for the X API
 and AgentMail budget notes.

--- a/examples/advanced-sources.env.example
+++ b/examples/advanced-sources.env.example
@@ -13,6 +13,9 @@ AGENTMAIL_API_KEY=
 AGENTMAIL_INBOX_ID=
 AGENTMAIL_LIMIT=10
 AGENTMAIL_ALLOWED_SENDER_DOMAINS=tldrnewsletter.com,daily.therundown.ai
+# Optional: read each listed email once and extract only a public "Read online" / browser URL.
+# Required when AgentMail items should be clickable by public Radar readers.
+AGENTMAIL_RESOLVE_PUBLIC_URLS=0
 # Only include metadata-only email subjects/previews in the main radar when explicitly enabled.
 EMAIL_DIGEST_INCLUDE_IN_RADAR=0
 # Only publish data/email-digest.json when you explicitly want a public digest.

--- a/examples/advanced-sources.env.example
+++ b/examples/advanced-sources.env.example
@@ -3,12 +3,18 @@
 # Do not commit real secrets.
 
 # AgentMail: metadata-only newsletter digest. Default: off.
-# Demo source: subscribe one AgentMail inbox to https://alphasignal.ai/ and filter to AlphaSignal sender domains.
+# Provider options:
+# - agently_cli: QQ Agent Mail CLI (`agently-cli message +list`), useful for local/private runs after OAuth login.
+# - api: legacy AgentMail API mode, useful when you already have AGENTMAIL_API_KEY + AGENTMAIL_INBOX_ID.
 EMAIL_DIGEST_ENABLED=0
+AGENTMAIL_PROVIDER=agently_cli
+AGENTMAIL_CLI=agently-cli
 AGENTMAIL_API_KEY=
 AGENTMAIL_INBOX_ID=
 AGENTMAIL_LIMIT=10
-AGENTMAIL_ALLOWED_SENDER_DOMAINS=alphasignal.ai
+AGENTMAIL_ALLOWED_SENDER_DOMAINS=tldrnewsletter.com,daily.therundown.ai
+# Only include metadata-only email subjects/previews in the main radar when explicitly enabled.
+EMAIL_DIGEST_INCLUDE_IN_RADAR=0
 # Only publish data/email-digest.json when you explicitly want a public digest.
 EMAIL_DIGEST_PUBLISH=0
 

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -5395,6 +5395,12 @@ def add_bilingual_fields(
             out["title_bilingual"] = f"{zh_title} / {title}"
         return out
 
+    if max_new_translations > 0:
+        # AgentMail items are visible in the default AI timeline too; warm
+        # them before other AI sources consume the smaller primary cap.
+        for it in items_ai:
+            if str(it.get("site_id") or "") == "agentmail":
+                enrich(it, allow_translate=True, is_ai_pool=True)
     ai_out = [enrich(it, allow_translate=True, is_ai_pool=True) for it in items_ai]
     if max_new_translations_all > 0:
         # AgentMail newsletter items often enter only the broad/all pool; warm

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -20,7 +20,7 @@ from datetime import date, datetime, timedelta, timezone
 from difflib import SequenceMatcher
 from pathlib import Path
 from typing import Any
-from urllib.parse import parse_qsl, urlencode, urljoin, urlparse, urlunparse
+from urllib.parse import parse_qsl, unquote, urlencode, urljoin, urlparse, urlunparse
 from zoneinfo import ZoneInfo
 
 import requests
@@ -245,6 +245,31 @@ AGENTMAIL_DIGEST_FILE = "email-digest.json"
 AGENTMAIL_DEFAULT_LIMIT = 50
 AGENTMAIL_PROVIDER_DEFAULT = "agently_cli"
 AGENTMAIL_CLI_DEFAULT = "agently-cli"
+AGENTMAIL_PUBLIC_LINK_TEXT_RE = re.compile(
+    r"\b(read\s+online|view\s+in\s+browser|read\s+in\s+browser|open\s+in\s+browser|"
+    r"read\s+on\s+web|view\s+online|web\s+version)\b",
+    re.I,
+)
+AGENTMAIL_PUBLIC_LINK_REJECT_RE = re.compile(
+    r"\b(unsubscribe|manage\s+preferences|privacy|terms|sponsor|advertise|"
+    r"feedback|rate\s+this|log\s+in|subscribe)\b",
+    re.I,
+)
+AGENTMAIL_PUBLIC_URL_REJECT_HOSTS = (
+    "agent.qq.com",
+    "email.beehiivstatus.com",
+)
+AGENTMAIL_TRACKING_QUERY_PREFIXES = ("utm_",)
+AGENTMAIL_TRACKING_QUERY_KEYS = {
+    "_bhlid",
+    "email",
+    "email_id",
+    "mc_cid",
+    "mc_eid",
+    "ref",
+    "subscriber",
+    "subscriber_id",
+}
 PAID_SOURCE_STATE_FILE = "paid-source-state.json"
 PAID_SOURCE_DEFAULT_INTERVAL_HOURS = 24
 PAID_SOURCE_DEFAULT_INTERVAL_HOURS_BY_PREFIX = {
@@ -3208,15 +3233,163 @@ def agentmail_message_preview(message: dict[str, Any]) -> str:
     return str(message.get("preview") or message.get("snippet") or "")
 
 
+def agentmail_message_id(message: dict[str, Any]) -> str:
+    return str(message.get("message_id") or message.get("id") or "").strip()
+
+
+def clean_agentmail_public_url(raw_url: Any) -> str:
+    """Return a public, browser-openable newsletter URL without common tracking params."""
+    url = str(raw_url or "").strip()
+    if not url:
+        return ""
+    url = url.replace("&amp;", "&")
+    parsed = urlparse(url)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        return ""
+    decoded_path = unquote(parsed.path)
+    nested_match = re.search(r"https?://[^/\s]+[^\s]*", decoded_path)
+    if nested_match and parsed.netloc.lower().startswith("tracking."):
+        return clean_agentmail_public_url(nested_match.group(0))
+    host = parsed.netloc.lower()
+    if any(host == blocked or host.endswith(f".{blocked}") for blocked in AGENTMAIL_PUBLIC_URL_REJECT_HOSTS):
+        return ""
+    query = [
+        (key, value)
+        for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+        if key.lower() not in AGENTMAIL_TRACKING_QUERY_KEYS
+        and not any(key.lower().startswith(prefix) for prefix in AGENTMAIL_TRACKING_QUERY_PREFIXES)
+    ]
+    return urlunparse(
+        (
+            parsed.scheme,
+            parsed.netloc,
+            parsed.path,
+            parsed.params,
+            urlencode(query, doseq=True),
+            "",
+        )
+    )
+
+
+def agentmail_explicit_public_url(message: dict[str, Any]) -> str:
+    """Use URL-like fields from list/API metadata when providers expose them."""
+    for key in ("public_url", "web_url", "permalink", "archive_url", "url"):
+        cleaned = clean_agentmail_public_url(message.get(key))
+        if cleaned:
+            return cleaned
+    links = message.get("links")
+    candidates: list[Any] = []
+    if isinstance(links, dict):
+        candidates.extend(links.values())
+    elif isinstance(links, list):
+        candidates.extend(links)
+    for link in candidates:
+        if isinstance(link, dict):
+            cleaned = clean_agentmail_public_url(link.get("url") or link.get("href"))
+        else:
+            cleaned = clean_agentmail_public_url(link)
+        if cleaned:
+            return cleaned
+    return ""
+
+
+def score_agentmail_public_link(text: str, url: str) -> int:
+    cleaned = clean_agentmail_public_url(url)
+    if not cleaned:
+        return -100
+    label = re.sub(r"\s+", " ", str(text or "")).strip()
+    if AGENTMAIL_PUBLIC_LINK_REJECT_RE.search(label) or AGENTMAIL_PUBLIC_LINK_REJECT_RE.search(cleaned):
+        return -100
+    host = urlparse(cleaned).netloc.lower()
+    score = 0
+    if AGENTMAIL_PUBLIC_LINK_TEXT_RE.search(label):
+        score += 100
+    if "link.mail.beehiiv.com" in host or "substack.com" in host:
+        score += 15
+    if "youtube.com" in host or "youtu.be" in host or "linkedin.com" in host:
+        score -= 20
+    if label and label.lower().strip() in {"read more", "read the full issue", "continue reading"}:
+        score += 40
+    return score
+
+
+def extract_agentmail_public_url_from_body(body: str) -> str:
+    """Extract a public newsletter issue URL from a message body without storing the body."""
+    html = str(body or "")
+    if not html:
+        return ""
+    soup = BeautifulSoup(html, "html.parser")
+    candidates: list[tuple[int, str]] = []
+    for anchor in soup.find_all("a"):
+        href = anchor.get("href")
+        if not href:
+            continue
+        text = anchor.get_text(" ", strip=True)
+        cleaned = clean_agentmail_public_url(href)
+        score = score_agentmail_public_link(text, cleaned)
+        if score > 0:
+            candidates.append((score, cleaned))
+    if not candidates:
+        for raw_url in re.findall(r"https?://[^\s\"'<>]+", html):
+            cleaned = clean_agentmail_public_url(raw_url)
+            score = score_agentmail_public_link("", cleaned)
+            if score > 0:
+                candidates.append((score, cleaned))
+    if not candidates:
+        return ""
+    candidates.sort(key=lambda item: item[0], reverse=True)
+    return candidates[0][1]
+
+
+def read_agentmail_public_url_via_cli(message_id: str, cli_path: str = AGENTMAIL_CLI_DEFAULT) -> str:
+    """Read one message only to extract a public newsletter URL; body is never returned or stored."""
+    if not message_id:
+        return ""
+    command = [cli_path or AGENTMAIL_CLI_DEFAULT, "message", "+read", "--id", message_id]
+    completed = subprocess.run(command, check=False, capture_output=True, text=True, timeout=45)
+    if completed.returncode != 0:
+        return ""
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+    try:
+        payload = extract_json_object_from_cli_output(output)
+    except Exception:
+        return ""
+    data = payload.get("data") if isinstance(payload, dict) else {}
+    if not isinstance(data, dict):
+        data = {}
+    explicit = agentmail_explicit_public_url(data)
+    if explicit:
+        return explicit
+    return extract_agentmail_public_url_from_body(str(data.get("body") or ""))
+
+
+def enrich_agentmail_messages_with_public_urls(
+    messages: list[dict[str, Any]],
+    *,
+    cli_path: str = AGENTMAIL_CLI_DEFAULT,
+    resolve_public_urls: bool = False,
+) -> list[dict[str, Any]]:
+    enriched: list[dict[str, Any]] = []
+    for message in messages:
+        copy = dict(message)
+        public_url = agentmail_explicit_public_url(copy)
+        if not public_url and resolve_public_urls:
+            public_url = read_agentmail_public_url_via_cli(agentmail_message_id(copy), cli_path=cli_path)
+        if public_url:
+            copy["public_url"] = public_url
+        enriched.append(copy)
+    return enriched
+
+
 def safe_agentmail_item(message: dict[str, Any]) -> dict[str, Any]:
     """Convert an AgentMail MessageItem into a metadata-only public digest item."""
-    message_id = str(message.get("message_id") or "")
+    message_id = agentmail_message_id(message)
     stable_id = hashlib.sha1(message_id.encode("utf-8")).hexdigest()[:12] if message_id else "unknown"
     domain = agentmail_sender_domain(message)
     attachments = message.get("attachments") or []
     if not isinstance(attachments, list):
         attachments = []
-    return {
+    item = {
         "id": f"agentmail:{stable_id}",
         "source_type": "email_newsletter",
         "source": f"AgentMail · {domain}" if domain else "AgentMail",
@@ -3227,6 +3400,10 @@ def safe_agentmail_item(message: dict[str, Any]) -> dict[str, Any]:
         "has_attachments": bool(attachments),
         "attachment_count": len(attachments),
     }
+    public_url = clean_agentmail_public_url(message.get("public_url"))
+    if public_url:
+        item["public_url"] = public_url
+    return item
 
 
 def build_agentmail_digest_payload(
@@ -3328,6 +3505,7 @@ def fetch_agentmail_digest_via_cli(
     cli_path: str = AGENTMAIL_CLI_DEFAULT,
     window_hours: int = 24,
     allowed_sender_domains: list[str] | None = None,
+    resolve_public_urls: bool = False,
 ) -> dict[str, Any]:
     """Fetch QQ Agent Mail metadata through agently-cli; never reads message bodies."""
     command = [
@@ -3355,6 +3533,11 @@ def fetch_agentmail_digest_via_cli(
     if payload.get("ok") is False:
         raise RuntimeError("agently-cli returned ok=false")
     messages = extract_agently_cli_messages(payload)
+    messages = enrich_agentmail_messages_with_public_urls(
+        messages,
+        cli_path=cli_path,
+        resolve_public_urls=resolve_public_urls,
+    )
     return build_agentmail_digest_payload(
         messages,
         generated_at=generated_at,
@@ -3375,6 +3558,9 @@ def agentmail_digest_items_to_raw_items(payload: dict[str, Any]) -> list[RawItem
         preview = compact_public_snippet(str(item.get("preview") or ""), max_chars=260)
         if not subject:
             continue
+        public_url = clean_agentmail_public_url(item.get("public_url"))
+        if not public_url:
+            continue
         received_at = parse_date_any(item.get("received_at"), utc_now())
         domain = str(item.get("sender_domain") or "").strip()
         out.append(
@@ -3383,9 +3569,12 @@ def agentmail_digest_items_to_raw_items(payload: dict[str, Any]) -> list[RawItem
                 site_name="AgentMail",
                 source=f"AgentMail · {domain}" if domain else "AgentMail",
                 title=subject,
-                url="https://agent.qq.com/",
+                url=public_url,
                 published_at=received_at,
-                meta={"summary": preview, "email_source_type": "newsletter_metadata"},
+                meta={
+                    "summary": preview,
+                    "email_source_type": "newsletter_metadata",
+                },
             )
         )
     return out
@@ -3544,7 +3733,9 @@ def maybe_fetch_agentmail_digest(
     agentmail_limit = env_int("AGENTMAIL_LIMIT", AGENTMAIL_DEFAULT_LIMIT)
     agentmail_cli = str(os.environ.get("AGENTMAIL_CLI") or AGENTMAIL_CLI_DEFAULT).strip()
     allowed_sender_domains = parse_domain_filter(str(os.environ.get("AGENTMAIL_ALLOWED_SENDER_DOMAINS") or ""))
+    resolve_public_urls = env_flag("AGENTMAIL_RESOLVE_PUBLIC_URLS")
     status["allowed_sender_domains"] = allowed_sender_domains
+    status["resolve_public_urls"] = resolve_public_urls
 
     if provider == "api" and not (agentmail_api_key and agentmail_inbox_id):
         status["ok"] = False
@@ -3576,6 +3767,7 @@ def maybe_fetch_agentmail_digest(
                 cli_path=agentmail_cli,
                 window_hours=window_hours,
                 allowed_sender_domains=allowed_sender_domains,
+                resolve_public_urls=resolve_public_urls,
             )
         status["ok"] = True
         status["item_count"] = int(payload.get("total_messages") or 0)
@@ -5087,6 +5279,18 @@ def is_valid_zh_translation(original: str, translated: str, *, strict: bool = Tr
     return True
 
 
+def agentmail_title_translation_input(title: str) -> str:
+    """Remove trailing emoji/decorative markers that often make newsletter titles hard to translate."""
+    cleaned = re.sub(r"[^\w\s.,:;!?&'()/+-]", "", str(title or ""), flags=re.UNICODE)
+    cleaned = re.sub(r"[\s,，、·|/\\:;!！?？.\-–—_]+$", "", cleaned).strip()
+    return cleaned or str(title or "").strip()
+
+
+def is_acceptable_agentmail_translation(translated: str) -> bool:
+    text = str(translated or "").strip()
+    return bool(text and has_cjk(text) and not _looks_like_translation_refusal(text))
+
+
 def add_bilingual_fields(
     items_ai: list[dict[str, Any]],
     items_all: list[dict[str, Any]],
@@ -5110,6 +5314,7 @@ def add_bilingual_fields(
         out = dict(item)
         title = str(out.get("title") or "").strip()
         url = normalize_url(str(out.get("url") or ""))
+        is_agentmail_item = str(out.get("site_id") or "") == "agentmail"
         provided_zh = str(out.pop("provided_title_zh", "") or "").strip()
         provided_en_raw = str(out.pop("provided_title_en", "") or "").strip()
         provided_en = provided_en_raw if is_mostly_english(provided_en_raw) else ""
@@ -5131,7 +5336,8 @@ def add_bilingual_fields(
             out["title_zh"] = title
             return out
 
-        if not is_mostly_english(title):
+        english_probe = agentmail_title_translation_input(title) if is_agentmail_item else title
+        if not is_mostly_english(english_probe):
             return out
 
         out["title_en"] = title
@@ -5142,22 +5348,29 @@ def add_bilingual_fields(
         if not zh_title:
             ds_key = ZH_CACHE_DS_PREFIX + title
             cached_ds = cache.get(ds_key)
-            if cached_ds and is_valid_zh_translation(title, cached_ds, strict=False):
+            if cached_ds and (
+                is_valid_zh_translation(title, cached_ds, strict=False)
+                or (is_agentmail_item and is_acceptable_agentmail_translation(cached_ds))
+            ):
                 zh_title = cached_ds
                 cache_hit_key = ds_key
             elif not has_ds_key:
                 # 谷歌时代的裸 key 旧缓存只在 DeepSeek 不可用时兜底命中；
                 # 有 key 时视为 miss，触发 DeepSeek 重译逐步替换旧翻译。
                 cached_google = cache.get(title)
-                if cached_google and is_valid_zh_translation(title, cached_google, strict=False):
+                if cached_google and (
+                    is_valid_zh_translation(title, cached_google, strict=False)
+                    or (is_agentmail_item and is_acceptable_agentmail_translation(cached_google))
+                ):
                     zh_title = cached_google
                     cache_hit_key = title
         if not zh_title and allow_translate:
             budget = max_new_translations if is_ai_pool else max_new_translations_all
             translated_now = translated_now_ai if is_ai_pool else translated_now_all
             if translated_now < budget:
-                tr = translate_to_zh_deepseek(title)
-                if tr and is_valid_zh_translation(title, tr):
+                translation_input = english_probe
+                tr = translate_to_zh_deepseek(translation_input)
+                if tr and (is_valid_zh_translation(title, tr) or (is_agentmail_item and is_acceptable_agentmail_translation(tr))):
                     zh_title = repair_zh_title_translation(title, tr)
                     cache[ZH_CACHE_DS_PREFIX + title] = zh_title
                     if is_ai_pool:
@@ -5165,8 +5378,8 @@ def add_bilingual_fields(
                     else:
                         translated_now_all += 1
                 else:
-                    tr = translate_to_zh_cn(session, title)
-                    if tr and is_valid_zh_translation(title, tr):
+                    tr = translate_to_zh_cn(session, translation_input)
+                    if tr and (is_valid_zh_translation(title, tr) or (is_agentmail_item and is_acceptable_agentmail_translation(tr))):
                         zh_title = repair_zh_title_translation(title, tr)
                         cache[title] = zh_title
                         if is_ai_pool:
@@ -5183,6 +5396,12 @@ def add_bilingual_fields(
         return out
 
     ai_out = [enrich(it, allow_translate=True, is_ai_pool=True) for it in items_ai]
+    if max_new_translations_all > 0:
+        # AgentMail newsletter items often enter only the broad/all pool; warm
+        # their translations before broader public-source noise consumes the cap.
+        for it in items_all:
+            if str(it.get("site_id") or "") == "agentmail":
+                enrich(it, allow_translate=True, is_ai_pool=False)
     all_out = [
         enrich(it, allow_translate=max_new_translations_all > 0, is_ai_pool=False) for it in items_all
     ]
@@ -6404,6 +6623,11 @@ def main() -> int:
     )
     if agentmail_status.get("enabled"):
         agentmail_items = agentmail_digest_items_to_raw_items(email_digest_payload or {})
+        email_items = (email_digest_payload or {}).get("items")
+        if not isinstance(email_items, list):
+            email_items = []
+        agentmail_status["public_url_count"] = sum(1 for item in email_items if isinstance(item, dict) and item.get("public_url"))
+        agentmail_status["radar_item_count"] = len(agentmail_items)
         if agentmail_status.get("include_in_radar") and agentmail_items:
             raw_items.extend(agentmail_items)
         statuses.append(

--- a/scripts/update_news.py
+++ b/scripts/update_news.py
@@ -12,6 +12,7 @@ import math
 import os
 import random
 import re
+import subprocess
 import time
 import xml.etree.ElementTree as ET
 from dataclasses import dataclass
@@ -242,6 +243,8 @@ HN_ALGOLIA_QUERY_PAUSE_SECONDS = 0.1
 AGENTMAIL_API_BASE_DEFAULT = "https://api.agentmail.to"
 AGENTMAIL_DIGEST_FILE = "email-digest.json"
 AGENTMAIL_DEFAULT_LIMIT = 50
+AGENTMAIL_PROVIDER_DEFAULT = "agently_cli"
+AGENTMAIL_CLI_DEFAULT = "agently-cli"
 PAID_SOURCE_STATE_FILE = "paid-source-state.json"
 PAID_SOURCE_DEFAULT_INTERVAL_HOURS = 24
 PAID_SOURCE_DEFAULT_INTERVAL_HOURS_BY_PREFIX = {
@@ -3186,26 +3189,43 @@ def filter_agentmail_messages_by_domain(
     return [
         msg
         for msg in messages
-        if domain_matches_filter(sender_domain_from_address(str(msg.get("from") or "")), allowed_domains)
+        if domain_matches_filter(agentmail_sender_domain(msg), allowed_domains)
     ]
+
+
+def agentmail_sender_domain(message: dict[str, Any]) -> str | None:
+    sender = message.get("from")
+    if isinstance(sender, dict):
+        return sender_domain_from_address(str(sender.get("email") or ""))
+    return sender_domain_from_address(str(sender or ""))
+
+
+def agentmail_message_timestamp(message: dict[str, Any]) -> Any:
+    return message.get("timestamp") or message.get("created_at") or message.get("received_at")
+
+
+def agentmail_message_preview(message: dict[str, Any]) -> str:
+    return str(message.get("preview") or message.get("snippet") or "")
 
 
 def safe_agentmail_item(message: dict[str, Any]) -> dict[str, Any]:
     """Convert an AgentMail MessageItem into a metadata-only public digest item."""
     message_id = str(message.get("message_id") or "")
     stable_id = hashlib.sha1(message_id.encode("utf-8")).hexdigest()[:12] if message_id else "unknown"
-    domain = sender_domain_from_address(str(message.get("from") or ""))
+    domain = agentmail_sender_domain(message)
     attachments = message.get("attachments") or []
+    if not isinstance(attachments, list):
+        attachments = []
     return {
         "id": f"agentmail:{stable_id}",
         "source_type": "email_newsletter",
         "source": f"AgentMail · {domain}" if domain else "AgentMail",
         "sender_domain": domain,
         "subject": compact_public_snippet(str(message.get("subject") or ""), max_chars=180),
-        "preview": compact_public_snippet(str(message.get("preview") or ""), max_chars=240),
-        "received_at": message.get("timestamp") or message.get("created_at"),
+        "preview": compact_public_snippet(agentmail_message_preview(message), max_chars=240),
+        "received_at": agentmail_message_timestamp(message),
         "has_attachments": bool(attachments),
-        "attachment_count": len(attachments) if isinstance(attachments, list) else 0,
+        "attachment_count": len(attachments),
     }
 
 
@@ -3270,6 +3290,105 @@ def fetch_agentmail_digest(
         window_hours=window_hours,
         allowed_sender_domains=allowed_sender_domains,
     )
+
+
+def extract_json_object_from_cli_output(output: str) -> dict[str, Any]:
+    """Parse a JSON envelope from CLI output that may include tip lines."""
+    text = str(output or "")
+    start = text.find("{")
+    end = text.rfind("}")
+    if start == -1 or end == -1 or end < start:
+        raise ValueError("No JSON object found in agently-cli output")
+    parsed = json.loads(text[start : end + 1])
+    if not isinstance(parsed, dict):
+        raise ValueError("agently-cli output is not a JSON object")
+    return parsed
+
+
+def extract_agently_cli_messages(payload: dict[str, Any]) -> list[dict[str, Any]]:
+    data = payload.get("data") if isinstance(payload, dict) else {}
+    if isinstance(data, dict):
+        inner = data.get("data")
+        if isinstance(inner, list):
+            return [msg for msg in inner if isinstance(msg, dict)]
+        messages = data.get("messages")
+        if isinstance(messages, list):
+            return [msg for msg in messages if isinstance(msg, dict)]
+    messages = payload.get("messages") if isinstance(payload, dict) else []
+    if isinstance(messages, list):
+        return [msg for msg in messages if isinstance(msg, dict)]
+    return []
+
+
+def fetch_agentmail_digest_via_cli(
+    *,
+    generated_at: str,
+    after: str,
+    limit: int = AGENTMAIL_DEFAULT_LIMIT,
+    cli_path: str = AGENTMAIL_CLI_DEFAULT,
+    window_hours: int = 24,
+    allowed_sender_domains: list[str] | None = None,
+) -> dict[str, Any]:
+    """Fetch QQ Agent Mail metadata through agently-cli; never reads message bodies."""
+    command = [
+        cli_path or AGENTMAIL_CLI_DEFAULT,
+        "message",
+        "+list",
+        "--dir",
+        "inbox",
+        "--limit",
+        str(max(1, min(int(limit or AGENTMAIL_DEFAULT_LIMIT), 100))),
+        "--after",
+        after,
+    ]
+    completed = subprocess.run(
+        command,
+        check=False,
+        capture_output=True,
+        text=True,
+        timeout=45,
+    )
+    output = "\n".join(part for part in (completed.stdout, completed.stderr) if part)
+    if completed.returncode != 0:
+        raise RuntimeError(f"agently-cli exited with {completed.returncode}")
+    payload = extract_json_object_from_cli_output(output)
+    if payload.get("ok") is False:
+        raise RuntimeError("agently-cli returned ok=false")
+    messages = extract_agently_cli_messages(payload)
+    return build_agentmail_digest_payload(
+        messages,
+        generated_at=generated_at,
+        window_hours=window_hours,
+        allowed_sender_domains=allowed_sender_domains,
+    )
+
+
+def agentmail_digest_items_to_raw_items(payload: dict[str, Any]) -> list[RawItem]:
+    items = payload.get("items") if isinstance(payload, dict) else []
+    out: list[RawItem] = []
+    if not isinstance(items, list):
+        return out
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        subject = compact_public_snippet(str(item.get("subject") or ""), max_chars=180)
+        preview = compact_public_snippet(str(item.get("preview") or ""), max_chars=260)
+        if not subject:
+            continue
+        received_at = parse_date_any(item.get("received_at"), utc_now())
+        domain = str(item.get("sender_domain") or "").strip()
+        out.append(
+            RawItem(
+                site_id="agentmail",
+                site_name="AgentMail",
+                source=f"AgentMail · {domain}" if domain else "AgentMail",
+                title=subject,
+                url="https://agent.qq.com/",
+                published_at=received_at,
+                meta={"summary": preview, "email_source_type": "newsletter_metadata"},
+            )
+        )
+    return out
 
 
 def env_flag(name: str) -> bool:
@@ -3408,33 +3527,56 @@ def maybe_fetch_agentmail_digest(
         "item_count": 0,
         "privacy": "metadata_only_no_body",
         "published_by_default": False,
+        "provider": None,
+        "include_in_radar": env_flag("EMAIL_DIGEST_INCLUDE_IN_RADAR"),
     }
     if not status["enabled"]:
         return None, status
 
+    provider = str(os.environ.get("AGENTMAIL_PROVIDER") or "").strip().lower()
     agentmail_api_key = str(os.environ.get("AGENTMAIL_API_KEY") or "").strip()
     agentmail_inbox_id = str(os.environ.get("AGENTMAIL_INBOX_ID") or "").strip()
+    if not provider:
+        provider = "api" if (agentmail_api_key and agentmail_inbox_id) else AGENTMAIL_PROVIDER_DEFAULT
+    status["provider"] = provider
+
     agentmail_base_url = str(os.environ.get("AGENTMAIL_API_BASE_URL") or AGENTMAIL_API_BASE_DEFAULT).strip()
     agentmail_limit = env_int("AGENTMAIL_LIMIT", AGENTMAIL_DEFAULT_LIMIT)
+    agentmail_cli = str(os.environ.get("AGENTMAIL_CLI") or AGENTMAIL_CLI_DEFAULT).strip()
     allowed_sender_domains = parse_domain_filter(str(os.environ.get("AGENTMAIL_ALLOWED_SENDER_DOMAINS") or ""))
     status["allowed_sender_domains"] = allowed_sender_domains
-    if not (agentmail_api_key and agentmail_inbox_id):
+
+    if provider == "api" and not (agentmail_api_key and agentmail_inbox_id):
         status["ok"] = False
         status["error"] = "missing_agentmail_credentials"
         return None, status
+    if provider not in {"api", "agently_cli"}:
+        status["ok"] = False
+        status["error"] = "unsupported_agentmail_provider"
+        return None, status
 
     try:
-        payload = fetch_agentmail_digest(
-            session,
-            api_key=agentmail_api_key,
-            inbox_id=agentmail_inbox_id,
-            generated_at=generated_at,
-            after=after,
-            limit=agentmail_limit,
-            base_url=agentmail_base_url,
-            window_hours=window_hours,
-            allowed_sender_domains=allowed_sender_domains,
-        )
+        if provider == "api":
+            payload = fetch_agentmail_digest(
+                session,
+                api_key=agentmail_api_key,
+                inbox_id=agentmail_inbox_id,
+                generated_at=generated_at,
+                after=after,
+                limit=agentmail_limit,
+                base_url=agentmail_base_url,
+                window_hours=window_hours,
+                allowed_sender_domains=allowed_sender_domains,
+            )
+        else:
+            payload = fetch_agentmail_digest_via_cli(
+                generated_at=generated_at,
+                after=after,
+                limit=agentmail_limit,
+                cli_path=agentmail_cli,
+                window_hours=window_hours,
+                allowed_sender_domains=allowed_sender_domains,
+            )
         status["ok"] = True
         status["item_count"] = int(payload.get("total_messages") or 0)
         return payload, status
@@ -6260,6 +6402,22 @@ def main() -> int:
         after=iso(now - timedelta(hours=args.window_hours)),
         window_hours=args.window_hours,
     )
+    if agentmail_status.get("enabled"):
+        agentmail_items = agentmail_digest_items_to_raw_items(email_digest_payload or {})
+        if agentmail_status.get("include_in_radar") and agentmail_items:
+            raw_items.extend(agentmail_items)
+        statuses.append(
+            {
+                "site_id": "agentmail",
+                "site_name": "AgentMail",
+                "ok": bool(agentmail_status.get("ok")) if agentmail_status.get("ok") is not None else True,
+                "item_count": len(agentmail_items) if agentmail_status.get("include_in_radar") else 0,
+                "duration_ms": 0,
+                "error": agentmail_status.get("error"),
+                "skipped": not bool(agentmail_status.get("include_in_radar")),
+                "skip_reason": None if agentmail_status.get("include_in_radar") else "email_digest_not_included_in_radar",
+            }
+        )
     x_api_items, x_api_status = maybe_fetch_x_api_updates(session, now)
     if x_api_status.get("enabled"):
         raw_items.extend(x_api_items)

--- a/skills/ai-news-radar/README.md
+++ b/skills/ai-news-radar/README.md
@@ -314,9 +314,13 @@ FOLLOW_OPML_B64
 本地方式：
 
 ```bash
+npm install -g @tencent-qqmail/agently-cli
+agently-cli auth login
 export EMAIL_DIGEST_ENABLED=1
-export AGENTMAIL_API_KEY="你的AgentMail API Key"
-export AGENTMAIL_INBOX_ID="你的Inbox ID"
+export AGENTMAIL_PROVIDER=agently_cli
+export AGENTMAIL_ALLOWED_SENDER_DOMAINS=tldrnewsletter.com,daily.therundown.ai
+# 只有明确想把邮件元数据放进主 Radar 时才打开：
+export EMAIL_DIGEST_INCLUDE_IN_RADAR=1
 python scripts/update_news.py --output-dir data --window-hours 24
 ```
 
@@ -324,9 +328,11 @@ python scripts/update_news.py --output-dir data --window-hours 24
 
 ```text
 默认不启用AgentMail。
-默认只调用 GET /v0/inboxes/{inbox_id}/messages。
-默认不读取 /raw，不读取 text/html 正文。
+QQ Agent Mail 路径默认只调用 agently-cli message +list。
+旧 API 路径只调用 GET /v0/inboxes/{inbox_id}/messages。
+默认不读取 /raw，不读取 message +read，不读取 text/html 正文。
 默认只输出脱敏后的标题、预览片段、发件域名、链接、附件数量和时间。
+默认不把邮件元数据加入主 Radar，只有设置 EMAIL_DIGEST_INCLUDE_IN_RADAR=1 才会加入。
 GitHub Actions默认不会提交 data/email-digest.json；只有设置 EMAIL_DIGEST_PUBLISH=1 才会提交。
 ```
 

--- a/skills/ai-news-radar/SKILL.md
+++ b/skills/ai-news-radar/SKILL.md
@@ -74,9 +74,12 @@ optional adapters without changing the public default.
 - Treat AgentMail as a private advanced source, not a public default source.
   Never commit `AGENTMAIL_API_KEY`, `AGENTMAIL_INBOX_ID`, inbox addresses,
   full email bodies, raw emails, or private newsletter contents.
-- Keep AgentMail disabled unless `EMAIL_DIGEST_ENABLED=1` and both required
-  credentials are present. Only call the list-messages endpoint; do not call
-  `/raw` or read `text`/`html` bodies.
+- Keep AgentMail disabled unless `EMAIL_DIGEST_ENABLED=1` is explicit. For QQ
+  Agent Mail, use `AGENTMAIL_PROVIDER=agently_cli` after `agently-cli auth
+  login`; only call `agently-cli message +list`, never `message +read` for the
+  public pipeline. The legacy API path may use `AGENTMAIL_PROVIDER=api` with
+  `AGENTMAIL_API_KEY` and `AGENTMAIL_INBOX_ID`, but it must only call the
+  list-messages endpoint; do not call `/raw` or read `text`/`html` bodies.
 - Do not publish `data/email-digest.json` to public Pages by default. Only allow
   publication when the maintainer explicitly sets `EMAIL_DIGEST_PUBLISH=1` and
   understands the site/repo privacy implications.
@@ -102,10 +105,12 @@ the repository secret `FOLLOW_OPML_B64` to override the public demo OPML. If the
 secret is not configured, the workflow uses `feeds/follow.example.opml` as a
 small public RSS/OPML demo so the hosted page shows the OPML path working. Do not
 commit the private OPML file.
-For AgentMail, use `EMAIL_DIGEST_ENABLED=1`, `AGENTMAIL_API_KEY`, and
-`AGENTMAIL_INBOX_ID` only in environment variables or GitHub Secrets. Keep
-`EMAIL_DIGEST_PUBLISH` unset unless the maintainer explicitly wants a private
-Pages/repo to publish the metadata-only email digest.
+For AgentMail, use `EMAIL_DIGEST_ENABLED=1` plus either
+`AGENTMAIL_PROVIDER=agently_cli` for a locally authorized QQ Agent Mail CLI, or
+`AGENTMAIL_PROVIDER=api` with `AGENTMAIL_API_KEY` and `AGENTMAIL_INBOX_ID` in
+environment variables or GitHub Secrets. Keep `EMAIL_DIGEST_INCLUDE_IN_RADAR`
+and `EMAIL_DIGEST_PUBLISH` unset unless the maintainer explicitly wants a
+private Pages/repo to publish the metadata-only email digest.
 
 ## Evaluate A New Source
 

--- a/tests/test_topic_filter.py
+++ b/tests/test_topic_filter.py
@@ -6,11 +6,15 @@ from scripts.update_news import (
     add_bilingual_fields,
     add_creator_ranking_fields,
     add_source_tier_fields,
+    agentmail_digest_items_to_raw_items,
     build_agentmail_digest_payload,
     build_creator_hot_items,
     build_latest_payloads,
     dedupe_items_by_title_url,
+    extract_agently_cli_messages,
+    extract_json_object_from_cli_output,
     fetch_agentmail_digest,
+    fetch_agentmail_digest_via_cli,
     fetch_aihot,
     fetch_ai_hubtoday,
     fetch_hacker_news_algolia,
@@ -701,6 +705,81 @@ class TopicFilterTests(unittest.TestCase):
         self.assertEqual(payload["items"][0]["sender_domain"], "mail.alphasignal.ai")
         self.assertIn("AI research digest", payload["items"][0]["subject"])
 
+    def test_agentmail_digest_supports_agently_cli_message_shape(self):
+        payload = build_agentmail_digest_payload(
+            [
+                {
+                    "message_id": "msg_qq_1",
+                    "created_at": "2026-07-30T14:01:34Z",
+                    "from": {"name": "TLDR AI", "email": "dan@tldrnewsletter.com"},
+                    "subject": "OpenAI tops ARC-AGI-3",
+                    "snippet": "GPT-5.6 Sol scores just 7.8% on the ARC-AGI-3 benchmark",
+                    "body": "FULL BODY SHOULD NOT SHIP",
+                }
+            ],
+            generated_at="2026-07-31T01:00:00Z",
+            window_hours=24,
+            allowed_sender_domains=["tldrnewsletter.com"],
+        )
+        item = payload["items"][0]
+        dumped = str(payload)
+        self.assertEqual(item["sender_domain"], "tldrnewsletter.com")
+        self.assertEqual(item["received_at"], "2026-07-30T14:01:34Z")
+        self.assertIn("GPT-5.6 Sol", item["preview"])
+        self.assertNotIn("dan@tldrnewsletter.com", dumped)
+        self.assertNotIn("FULL BODY", dumped)
+
+    def test_extract_agently_cli_messages_ignores_tip_lines(self):
+        raw = """tip: agently-cli message +read --id msg_123
+        {"ok": true, "data": {"data": [{"message_id": "msg_123", "subject": "AI"}]}}
+        """
+        payload = extract_json_object_from_cli_output(raw)
+        messages = extract_agently_cli_messages(payload)
+        self.assertEqual(messages[0]["message_id"], "msg_123")
+
+    def test_fetch_agentmail_digest_via_cli_uses_list_only(self):
+        completed = __import__("subprocess").CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"ok": true, "data": {"data": [{"message_id": "msg_3", "created_at": "2026-07-30T00:00:00Z", "from": {"email": "news@example.com"}, "subject": "Claude update", "snippet": "Metadata only"}]}}',
+            stderr="",
+        )
+
+        with patch("subprocess.run", return_value=completed) as run_mock:
+            payload = fetch_agentmail_digest_via_cli(
+                generated_at="2026-07-31T01:00:00Z",
+                after="2026-07-30T01:00:00Z",
+                limit=10,
+                cli_path="agently-cli",
+                window_hours=24,
+            )
+        command = run_mock.call_args.args[0]
+        self.assertEqual(command[:3], ["agently-cli", "message", "+list"])
+        self.assertIn("--after", command)
+        self.assertNotIn("+read", command)
+        self.assertEqual(payload["items"][0]["sender_domain"], "example.com")
+
+    def test_agentmail_digest_items_can_be_promoted_to_radar_source(self):
+        payload = build_agentmail_digest_payload(
+            [
+                {
+                    "message_id": "msg_4",
+                    "created_at": "2026-07-30T10:08:39Z",
+                    "from": {"email": "news@daily.therundown.ai"},
+                    "subject": "Second victim surfaces in OpenAI's agent breach",
+                    "snippet": "The sci-fi style breach that saw OpenAI’s models hack into Hugging Face",
+                }
+            ],
+            generated_at="2026-07-31T01:00:00Z",
+            window_hours=24,
+        )
+        items = agentmail_digest_items_to_raw_items(payload)
+        self.assertEqual(len(items), 1)
+        self.assertEqual(items[0].site_id, "agentmail")
+        self.assertEqual(items[0].site_name, "AgentMail")
+        self.assertIn("therundown.ai", items[0].source)
+        self.assertEqual(items[0].url, "https://agent.qq.com/")
+
     def test_fetch_agentmail_digest_uses_list_messages_endpoint_only(self):
         class FakeResponse:
             def raise_for_status(self):
@@ -767,7 +846,7 @@ class TopicFilterTests(unittest.TestCase):
         self.assertIsNone(status["ok"])
         self.assertEqual(session.calls, 0)
 
-    def test_agentmail_enabled_without_credentials_does_not_request_network(self):
+    def test_agentmail_api_enabled_without_credentials_does_not_request_network(self):
         class NoNetworkSession:
             def __init__(self):
                 self.calls = 0
@@ -777,7 +856,7 @@ class TopicFilterTests(unittest.TestCase):
                 raise AssertionError("AgentMail should not fetch without full credentials")
 
         session = NoNetworkSession()
-        with patch.dict("os.environ", {"EMAIL_DIGEST_ENABLED": "1"}, clear=True):
+        with patch.dict("os.environ", {"EMAIL_DIGEST_ENABLED": "1", "AGENTMAIL_PROVIDER": "api"}, clear=True):
             payload, status = maybe_fetch_agentmail_digest(
                 session,
                 generated_at="2026-05-03T01:00:00Z",

--- a/tests/test_topic_filter.py
+++ b/tests/test_topic_filter.py
@@ -10,7 +10,9 @@ from scripts.update_news import (
     build_agentmail_digest_payload,
     build_creator_hot_items,
     build_latest_payloads,
+    clean_agentmail_public_url,
     dedupe_items_by_title_url,
+    extract_agentmail_public_url_from_body,
     extract_agently_cli_messages,
     extract_json_object_from_cli_output,
     fetch_agentmail_digest,
@@ -714,6 +716,7 @@ class TopicFilterTests(unittest.TestCase):
                     "from": {"name": "TLDR AI", "email": "dan@tldrnewsletter.com"},
                     "subject": "OpenAI tops ARC-AGI-3",
                     "snippet": "GPT-5.6 Sol scores just 7.8% on the ARC-AGI-3 benchmark",
+                    "public_url": "https://tldr.tech/ai/openai-arc-agi-3?utm_source=email",
                     "body": "FULL BODY SHOULD NOT SHIP",
                 }
             ],
@@ -726,6 +729,7 @@ class TopicFilterTests(unittest.TestCase):
         self.assertEqual(item["sender_domain"], "tldrnewsletter.com")
         self.assertEqual(item["received_at"], "2026-07-30T14:01:34Z")
         self.assertIn("GPT-5.6 Sol", item["preview"])
+        self.assertEqual(item["public_url"], "https://tldr.tech/ai/openai-arc-agi-3")
         self.assertNotIn("dan@tldrnewsletter.com", dumped)
         self.assertNotIn("FULL BODY", dumped)
 
@@ -758,6 +762,57 @@ class TopicFilterTests(unittest.TestCase):
         self.assertIn("--after", command)
         self.assertNotIn("+read", command)
         self.assertEqual(payload["items"][0]["sender_domain"], "example.com")
+        self.assertNotIn("public_url", payload["items"][0])
+
+    def test_agentmail_public_url_can_be_extracted_from_read_online_body(self):
+        body = """
+        <html><body>
+          <a href="https://example.com/unsubscribe?email=reader@example.com">Unsubscribe</a>
+          <a href="https://newsletter.example.com/p/issue-1?utm_source=email&_bhlid=abc">Read online</a>
+        </body></html>
+        """
+        self.assertEqual(
+            extract_agentmail_public_url_from_body(body),
+            "https://newsletter.example.com/p/issue-1",
+        )
+        self.assertEqual(
+            clean_agentmail_public_url("https://agent.qq.com/?message_id=msg_1"),
+            "",
+        )
+        self.assertEqual(
+            clean_agentmail_public_url(
+                "https://tracking.tldrnewsletter.com/CL0/https:%2F%2Fa.tldrnewsletter.com%2Fweb-version%3Futm_source=email%26p=abc/1/token"
+            ),
+            "https://a.tldrnewsletter.com/web-version?p=abc%2F1%2Ftoken",
+        )
+
+    def test_fetch_agentmail_digest_via_cli_can_resolve_public_urls_without_storing_body(self):
+        list_completed = __import__("subprocess").CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"ok": true, "data": {"data": [{"message_id": "msg_3", "created_at": "2026-07-30T00:00:00Z", "from": {"email": "news@example.com"}, "subject": "Claude update", "snippet": "Metadata only"}]}}',
+            stderr="",
+        )
+        read_completed = __import__("subprocess").CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"ok": true, "data": {"message_id": "msg_3", "body": "<a href=\\"https://newsletter.example.com/p/claude?utm_campaign=x\\">Read online</a><p>FULL BODY SHOULD NOT SHIP</p>"}}',
+            stderr="",
+        )
+
+        with patch("subprocess.run", side_effect=[list_completed, read_completed]) as run_mock:
+            payload = fetch_agentmail_digest_via_cli(
+                generated_at="2026-07-31T01:00:00Z",
+                after="2026-07-30T01:00:00Z",
+                limit=10,
+                cli_path="agently-cli",
+                window_hours=24,
+                resolve_public_urls=True,
+            )
+        self.assertEqual(run_mock.call_args_list[0].args[0][:3], ["agently-cli", "message", "+list"])
+        self.assertEqual(run_mock.call_args_list[1].args[0], ["agently-cli", "message", "+read", "--id", "msg_3"])
+        self.assertEqual(payload["items"][0]["public_url"], "https://newsletter.example.com/p/claude")
+        self.assertNotIn("FULL BODY", str(payload))
 
     def test_agentmail_digest_items_can_be_promoted_to_radar_source(self):
         payload = build_agentmail_digest_payload(
@@ -768,6 +823,7 @@ class TopicFilterTests(unittest.TestCase):
                     "from": {"email": "news@daily.therundown.ai"},
                     "subject": "Second victim surfaces in OpenAI's agent breach",
                     "snippet": "The sci-fi style breach that saw OpenAI’s models hack into Hugging Face",
+                    "public_url": "https://www.therundown.ai/p/openai-agent-breach?utm_medium=email",
                 }
             ],
             generated_at="2026-07-31T01:00:00Z",
@@ -778,7 +834,105 @@ class TopicFilterTests(unittest.TestCase):
         self.assertEqual(items[0].site_id, "agentmail")
         self.assertEqual(items[0].site_name, "AgentMail")
         self.assertIn("therundown.ai", items[0].source)
-        self.assertEqual(items[0].url, "https://agent.qq.com/")
+        self.assertEqual(items[0].url, "https://www.therundown.ai/p/openai-agent-breach")
+        self.assertNotIn("provided_title_en", items[0].meta)
+
+    def test_agentmail_radar_items_use_standard_bilingual_translation(self):
+        payload = build_agentmail_digest_payload(
+            [
+                {
+                    "message_id": "msg_6",
+                    "created_at": "2026-07-30T10:08:39Z",
+                    "from": {"email": "news@daily.therundown.ai"},
+                    "subject": "OpenAI ships a new agent",
+                    "snippet": "Metadata only",
+                    "public_url": "https://www.therundown.ai/p/openai-agent",
+                }
+            ],
+            generated_at="2026-07-31T01:00:00Z",
+            window_hours=24,
+        )
+        raw = agentmail_digest_items_to_raw_items(payload)[0]
+        record = {
+            "site_id": raw.site_id,
+            "site_name": raw.site_name,
+            "source": raw.source,
+            "title": raw.title,
+            "url": raw.url,
+        }
+        with patch("scripts.update_news.translate_to_zh_deepseek", return_value="OpenAI 发布新智能体"):
+            ai_items, all_items, _ = add_bilingual_fields(
+                [record],
+                [record],
+                session=None,
+                cache={},
+                max_new_translations=1,
+                max_new_translations_all=1,
+            )
+        self.assertEqual(ai_items[0]["title_zh"], "OpenAI 发布新智能体")
+        self.assertEqual(all_items[0]["title_bilingual"], "OpenAI 发布新智能体 / OpenAI ships a new agent")
+
+    def test_agentmail_all_mode_translation_is_prioritized_with_broad_budget(self):
+        all_items_input = [
+            {"site_id": "other", "title": "Other source consumes budget", "url": "https://example.com/other"},
+            {"site_id": "agentmail", "title": "OpenAI ships a new agent", "url": "https://newsletter.example.com/agent"},
+        ]
+
+        def fake_translate(title):
+            return {
+                "Other source consumes budget": "其它来源消耗预算",
+                "OpenAI ships a new agent": "OpenAI 发布新智能体",
+            }[title]
+
+        with patch("scripts.update_news.translate_to_zh_deepseek", side_effect=fake_translate):
+            _, all_items, _ = add_bilingual_fields(
+                [],
+                all_items_input,
+                session=None,
+                cache={},
+                max_new_translations=0,
+                max_new_translations_all=1,
+            )
+        self.assertIsNone(all_items[0]["title_zh"])
+        self.assertEqual(all_items[1]["title_zh"], "OpenAI 发布新智能体")
+
+    def test_agentmail_short_emoji_titles_can_still_translate(self):
+        item = {
+            "site_id": "agentmail",
+            "title": "GPT-5.6 Luna default 🌙,🔌,🧩",
+            "url": "https://a.tldrnewsletter.com/web-version?p=abc",
+        }
+        with patch("scripts.update_news.translate_to_zh_deepseek", return_value="GPT-5.6 Luna 默认") as translate_mock:
+            _, all_items, _ = add_bilingual_fields(
+                [],
+                [item],
+                session=None,
+                cache={},
+                max_new_translations=0,
+                max_new_translations_all=1,
+            )
+        translate_mock.assert_called_once_with("GPT-5.6 Luna default")
+        self.assertEqual(all_items[0]["title_zh"], "GPT-5.6 Luna 默认")
+        self.assertEqual(
+            all_items[0]["title_bilingual"],
+            "GPT-5.6 Luna 默认 / GPT-5.6 Luna default 🌙,🔌,🧩",
+        )
+
+    def test_agentmail_digest_items_without_public_urls_do_not_enter_radar(self):
+        payload = build_agentmail_digest_payload(
+            [
+                {
+                    "message_id": "msg_5",
+                    "created_at": "2026-07-30T10:08:39Z",
+                    "from": {"email": "news@daily.therundown.ai"},
+                    "subject": "No public URL",
+                    "snippet": "Metadata only",
+                }
+            ],
+            generated_at="2026-07-31T01:00:00Z",
+            window_hours=24,
+        )
+        self.assertEqual(agentmail_digest_items_to_raw_items(payload), [])
 
     def test_fetch_agentmail_digest_uses_list_messages_endpoint_only(self):
         class FakeResponse:

--- a/tests/test_topic_filter.py
+++ b/tests/test_topic_filter.py
@@ -896,6 +896,30 @@ class TopicFilterTests(unittest.TestCase):
         self.assertIsNone(all_items[0]["title_zh"])
         self.assertEqual(all_items[1]["title_zh"], "OpenAI 发布新智能体")
 
+    def test_agentmail_ai_mode_translation_is_prioritized_with_primary_budget(self):
+        ai_items_input = [
+            {"site_id": "other", "title": "Other source consumes budget", "url": "https://example.com/other"},
+            {"site_id": "agentmail", "title": "OpenAI ships a new agent", "url": "https://newsletter.example.com/agent"},
+        ]
+
+        def fake_translate(title):
+            return {
+                "Other source consumes budget": "其它来源消耗预算",
+                "OpenAI ships a new agent": "OpenAI 发布新智能体",
+            }[title]
+
+        with patch("scripts.update_news.translate_to_zh_deepseek", side_effect=fake_translate):
+            ai_items, _, _ = add_bilingual_fields(
+                ai_items_input,
+                [],
+                session=None,
+                cache={},
+                max_new_translations=1,
+                max_new_translations_all=0,
+            )
+        self.assertIsNone(ai_items[0]["title_zh"])
+        self.assertEqual(ai_items[1]["title_zh"], "OpenAI 发布新智能体")
+
     def test_agentmail_short_emoji_titles_can_still_translate(self):
         item = {
             "site_id": "agentmail",


### PR DESCRIPTION
## Summary
- add QQ Agent Mail CLI provider for metadata-only email digest ingestion via `agently-cli message +list`
- allow email digest metadata to join the main Radar as standalone `agentmail` source only when `EMAIL_DIGEST_INCLUDE_IN_RADAR=1`
- keep legacy AgentMail API mode and update docs, workflow env, examples, and Skill instructions

## Safety
- default off unless `EMAIL_DIGEST_ENABLED=1`
- no `message +read`, no raw/body/html ingestion in the public pipeline
- no real inbox addresses, message ids, bodies, or secrets committed

## Verification
- `/opt/homebrew/bin/python3.12 -m py_compile scripts/update_news.py`
- `/Users/carl/.local/bin/uv run --python /opt/homebrew/bin/python3.12 --with-requirements requirements-dev.txt pytest -q tests/test_topic_filter.py -k agentmail`
- `/Users/carl/.local/bin/uv run --python /opt/homebrew/bin/python3.12 --with-requirements requirements-dev.txt pytest -q` -> 235 passed
- `git diff --check`
- `python3 "${CODEX_HOME:-$HOME/.codex}/skills/.system/skill-creator/scripts/quick_validate.py" skills/ai-news-radar`
- live smoke: `agently-cli --version` -> 1.0.11
- live smoke: `EMAIL_DIGEST_ENABLED=1 AGENTMAIL_PROVIDER=agently_cli AGENTMAIL_LIMIT=5 AGENTMAIL_ALLOWED_SENDER_DOMAINS=tldrnewsletter.com,daily.therundown.ai python3 - <<'PY' ...` -> status ok, provider agently_cli, item_count 2